### PR TITLE
Return empty result if continuation token's token is None.

### DIFF
--- a/google_play_scraper/features/reviews.py
+++ b/google_play_scraper/features/reviews.py
@@ -62,6 +62,12 @@ def reviews(
     if continuation_token is not None:
         token = continuation_token.token
 
+        if token is None:
+            return (
+                [],
+                continuation_token,
+            )
+
         lang = continuation_token.lang
         country = continuation_token.country
         sort = continuation_token.sort


### PR DESCRIPTION
Currently, when it reaches the end of reviews available, the reviews loop back to the start instead of stopping there. This will result in obtaining duplicate reviews unknowingly. Especially when generating popular apps with millions of reviews, it is hard to detect.

What this PR does is essentially make it so that it returns no further results if `continuation_token.token` is None. This will signal that there are no more reviews left to scrap. 

Some other possible addition to inform the users of the lib may be throwing an exception or log a warning.

Great lib btw, live saver for my deep learning project 😄 