### PR TITLE
app: Add simliar apps and more apps by developer lists to extracted data

### DIFF
--- a/google_play_scraper/constants/element.py
+++ b/google_play_scraper/constants/element.py
@@ -117,6 +117,12 @@ class ElementSpecs:
             ElementSpec(17, [0], lambda container: [item[4] for item in container], []),
         ),
         "editorsChoice": ElementSpec(5, [0, 12, 15, 0], bool, False),
+        "similarApps": ElementSpec(7, [1, 1, 0, 0, 0], lambda container: [
+            container[i][12][0] for i in range(0, len(container))
+        ]),
+        "moreByDeveloper": ElementSpec(9, [0, 1, 0, 0, 0], lambda container: [
+            container[i][12][0] for i in range(0, len(container))
+        ]),
     }
 
     Review = {

--- a/tests/e2e_tests/test_app.py
+++ b/tests/e2e_tests/test_app.py
@@ -92,6 +92,8 @@ class TestApp(TestCase):
             "- Supports the newest devices.", result["recentChangesHTML"],
         )
         self.assertTrue(result["comments"])
+        self.assertTrue(result["similarApps"])
+        self.assertTrue(result["moreByDeveloper"])
 
     def test_e2e_scenario_2(self):
         """


### PR DESCRIPTION
This will add a list of similar apps packages to app info.
![image](https://user-images.githubusercontent.com/17043808/132091271-a2a44bf9-4d98-45e1-8e93-551103023070.png)

![image](https://user-images.githubusercontent.com/17043808/132091673-b006da05-98b9-4f19-bf56-5f13f907be4a.png)

```python
from google_play_scraper import app

app_info = app('air.com.Tatsuki.CookieBreaker')

print(app_info['similarApps'])
# ['com.cyberxgames.herotower2', 'com.Tatsuki.Tower', 'jp.oridio.taptaphammers', 'com.RuotoGames.DigAwayIdleMiningGame', 'com.studiodrill.bladecrafter2']

print(app_info['moreByDeveloper'])
# ['com.Tatsuki.Tower', 'air.infurerpgkuesuto', 'com.Tatsuki.bigsord', 'air.suiheisuizyunki']
```