### PR TITLE
permissions: Ensure permission is not null before adding it

### DIFF
--- a/google_play_scraper/features/permissions.py
+++ b/google_play_scraper/features/permissions.py
@@ -26,8 +26,9 @@ def permissions(app_id: str, lang: str = "en", country: str = "us") -> Dict[str,
                 permission_items = [["Uncategorized", None, permission_items, None]]
 
             for permission in permission_items:
-                result[
-                    ElementSpecs.Permission_Type.extract_content(permission)
-                ] = ElementSpecs.Permission_List.extract_content(permission)
+                if permission:
+                    result[
+                        ElementSpecs.Permission_Type.extract_content(permission)
+                    ] = ElementSpecs.Permission_List.extract_content(permission)
 
     return result


### PR DESCRIPTION
Some apps like [this app](https://play.google.com/store/apps/details?id=com.fekracomputers.islamiclibrary&hl=en) permissions' data contain empty elements in its list. This results in retuning dict with None name and value which should be handled correctly.

Before my change:
```
{None: None, 'Device & app history': ['read sensitive log data'], 'Photos/Media/Files': ['modify or delete the contents of your USB storage', 'read the contents of your USB storage'], 'Storage': ['modify or delete the contents of your USB storage', 'read the contents of your USB storage'], 'Other': ['full network access', 'prevent device from sleeping', 'view network connections'], 'Uncategorized': ['receive data from Internet']}
```

After change:
```
{'Device & app history': ['read sensitive log data'], 'Photos/Media/Files': ['modify or delete the contents of your USB storage', 'read the contents of your USB storage'], 'Storage': ['modify or delete the contents of your USB storage', 'read the contents of your USB storage'], 'Other': ['full network access', 'prevent device from sleeping', 'view network connections'], 'Uncategorized': ['receive data from Internet']}
```