### PR TITLE
Fallback url format for app details upon 404

### DIFF
--- a/google_play_scraper/constants/request.py
+++ b/google_play_scraper/constants/request.py
@@ -15,19 +15,29 @@ class Format(ABC):
 
 class Formats:
     class _Detail(Format):
-        URL_FORMAT = "{}/store/apps/details?id={{app_id}}&hl={{lang}}&gl={{country}}".format(
+        URL_FORMAT = (
+            "{}/store/apps/details?id={{app_id}}&hl={{lang}}&gl={{country}}".format(
+                PLAY_STORE_BASE_URL
+            )
+        )
+        FALLBACK_URL_FORMAT = "{}/store/apps/details?id={{app_id}}&hl={{lang}}".format(
             PLAY_STORE_BASE_URL
         )
 
         def build(self, app_id: str, lang: str, country: str) -> str:
             return self.URL_FORMAT.format(app_id=app_id, lang=lang, country=country)
 
+        def fallback_build(self, app_id: str, lang: str) -> str:
+            return self.FALLBACK_URL_FORMAT.format(app_id=app_id, lang=lang)
+
         def build_body(self, *args):
             return None
 
     class _Reviews(Format):
-        URL_FORMAT = "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
-            PLAY_STORE_BASE_URL
+        URL_FORMAT = (
+            "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
+                PLAY_STORE_BASE_URL
+            )
         )
 
         def build(self, lang: str, country: str) -> str:
@@ -60,8 +70,10 @@ class Formats:
             return result.encode()
 
     class _Permissions(Format):
-        URL_FORMAT = "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
-            PLAY_STORE_BASE_URL
+        URL_FORMAT = (
+            "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
+                PLAY_STORE_BASE_URL
+            )
         )
 
         def build(self, lang: str, country: str) -> str:

--- a/google_play_scraper/features/app.py
+++ b/google_play_scraper/features/app.py
@@ -5,12 +5,17 @@ from google_play_scraper.constants.element import ElementSpecs
 from google_play_scraper.constants.regex import Regex
 from google_play_scraper.constants.request import Formats
 from google_play_scraper.utils.request import get
+from google_play_scraper.exceptions import NotFoundError
 
 
 def app(app_id: str, lang: str = "en", country: str = "us") -> Dict[str, Any]:
     url = Formats.Detail.build(app_id=app_id, lang=lang, country=country)
 
-    dom = get(url)
+    try:
+        dom = get(url)
+    except NotFoundError:
+        url = Formats.Detail.fallback_build(app_id=app_id, lang=lang)
+        dom = get(url)
 
     matches = Regex.SCRIPT.findall(dom)
 


### PR DESCRIPTION
Sometimes when making a request for app details the request fails with a 404, but the same request works when the country parameter is omitted. I added some code to handle the 404 and try another request without the country parameter to improve the success rate when reading in and querying multiple package ids.