### PR TITLE
Adding fallback call for unsupported urls

### DIFF
--- a/google_play_scraper/constants/request.py
+++ b/google_play_scraper/constants/request.py
@@ -15,8 +15,10 @@ class Format(ABC):
 
 class Formats:
     class _Detail(Format):
-        URL_FORMAT = "{}/store/apps/details?id={{app_id}}&hl={{lang}}&gl={{country}}".format(
-            PLAY_STORE_BASE_URL
+        URL_FORMAT = (
+            "{}/store/apps/details?id={{app_id}}&hl={{lang}}&gl={{country}}".format(
+                PLAY_STORE_BASE_URL
+            )
         )
 
         def build(self, app_id: str, lang: str, country: str) -> str:
@@ -26,8 +28,10 @@ class Formats:
             return None
 
     class _Reviews(Format):
-        URL_FORMAT = "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
-            PLAY_STORE_BASE_URL
+        URL_FORMAT = (
+            "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
+                PLAY_STORE_BASE_URL
+            )
         )
 
         def build(self, lang: str, country: str) -> str:
@@ -60,8 +64,10 @@ class Formats:
             return result.encode()
 
     class _Permissions(Format):
-        URL_FORMAT = "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
-            PLAY_STORE_BASE_URL
+        URL_FORMAT = (
+            "{}/_/PlayStoreUi/data/batchexecute?hl={{lang}}&gl={{country}}".format(
+                PLAY_STORE_BASE_URL
+            )
         )
 
         def build(self, lang: str, country: str) -> str:

--- a/google_play_scraper/constants/request.py
+++ b/google_play_scraper/constants/request.py
@@ -20,9 +20,15 @@ class Formats:
                 PLAY_STORE_BASE_URL
             )
         )
+        FALLBACK_URL_FORMAT = "{}/store/apps/details?id={{app_id}}&hl={{lang}}".format(
+            PLAY_STORE_BASE_URL
+        )
 
         def build(self, app_id: str, lang: str, country: str) -> str:
             return self.URL_FORMAT.format(app_id=app_id, lang=lang, country=country)
+        
+        def fallback_build(self, app_id: str, lang: str) -> str:
+            return self.FALLBACK_URL_FORMAT.format(app_id=app_id, lang=lang)
 
         def build_body(self, *args):
             return None

--- a/google_play_scraper/features/app.py
+++ b/google_play_scraper/features/app.py
@@ -5,12 +5,17 @@ from google_play_scraper.constants.element import ElementSpecs
 from google_play_scraper.constants.regex import Regex
 from google_play_scraper.constants.request import Formats
 from google_play_scraper.utils.request import get
+from google_play_scraper.exceptions import NotFoundError
 
 
 def app(app_id: str, lang: str = "en", country: str = "us") -> Dict[str, Any]:
     url = Formats.Detail.build(app_id=app_id, lang=lang, country=country)
 
-    dom = get(url)
+    try:
+        dom = get(url)
+    except NotFoundError:
+        url = Formats.Detail.fallback_build(app_id=app_id, lang=lang)
+        dom = get(url)
 
     matches = Regex.SCRIPT.findall(dom)
 


### PR DESCRIPTION
In some cases the url would return a 404 even though it is a valid app. The reason for the 404 was the inclusion of the country parameter. Once it was removed the request worked as intended. To solve this I added a try exception to catch the 404 returned to app.py and make 1 more request to the same URL without the country parameter in case that was the reason for the failure.

An example of this:
https://play.google.com/store/apps/details?id=ca.walmart.ecommerceapp&hl=en&gl=us
https://play.google.com/store/apps/details?id=ca.walmart.ecommerceapp&hl=en