### PR TITLE
fix: app description mapping always localized;

### DIFF
--- a/google_play_scraper/constants/element.py
+++ b/google_play_scraper/constants/element.py
@@ -45,8 +45,12 @@ class ElementSpecs:
 
     Detail = {
         "title": ElementSpec(5, [1, 2, 0, 0]),
-        "description": ElementSpec(5, [1, 2, 72, 0, 1], unescape_text),
-        "descriptionHTML": ElementSpec(5, [1, 2, 72, 0, 1]),
+        "description": ElementSpec(
+            5, [1, 2], lambda s: unescape_text(nested_lookup(s, [12, 0, 0, 1]) or nested_lookup(s, [72, 0, 1]))
+        ),
+        "descriptionHTML": ElementSpec(
+            5, [1, 2], lambda s: nested_lookup(s, [12, 0, 0, 1]) or nested_lookup(s, [72, 0, 1])
+        ),
         "summary": ElementSpec(5, [1, 2, 73, 0, 1], unescape_text),
         "installs": ElementSpec(5, [1, 2, 13, 0]),
         "minInstalls": ElementSpec(5, [1, 2, 13, 1]),


### PR DESCRIPTION
This is basically the copy of [#623](https://github.com/facundoolano/google-play-scraper/pull/624) PR I did for the Facundo's repo. 

The problem in example:
```python
result = app(
    'ua.krou.maze',
    lang='uk',
    country='UA'
)
```
has returned `description` and `descriptionHTML` in English, even though GP has its translated verstion there -- https://play.google.com/store/apps/details?id=ua.krou.maze&hl=uk&gl=UA 

Solution: check for the translated version with a fallback to the original one.

Note: I have tried to do the same localization for the `search` but without success yet.