### PR TITLE
Add genres / categories list to App details result

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Result of `print(result)`:
     "privacyPolicy": "https://nianticlabs.com/privacy/pokemongo/en",
     "genre": "Adventure",
     "genreId": "GAME_ADVENTURE",
+    "categories": [
+        {"name": "Action", "id": "GAME_ACTION"},
+        {"name": "Action-adventure", "id": None},
+        {"name": "Multiplayer", "id": None},
+        {"name": "Competitive multiplayer", "id": None},
+        {"name": "Stylized", "id": None},
+        {"name": "Anime", "id": None},
+    ],
     "icon": "https://play-lh.googleusercontent.com/SVQIX_fYcu5mc4Pq-D7dgxXZdRMpNTAbRKeBJygAsIXKITHEcKckyhzLsIXMQLSRZw",
     "headerImage": "https://play-lh.googleusercontent.com/KgDQ-Kjb2B7_jDP-8KmQDNhAmP2lqAV_w3zArOCBL7YZnQ02Qqp4VTlgdocO-4MFk4s",
     "screenshots": [

--- a/google_play_scraper/constants/element.py
+++ b/google_play_scraper/constants/element.py
@@ -40,6 +40,28 @@ class ElementSpec:
 
         return result
 
+def extract_categories(s, categories = []):
+    if s == None or len(s) == 0:
+        return categories
+
+    if (len(s) >= 4 and type(s[0]) is str):
+        categories.append({ 'name': s[0], 'id': s[2] })
+    else:
+        for sub in s:
+            extract_categories(sub, categories)
+
+    return categories
+
+def get_categories(s):
+    categories = extract_categories(nested_lookup(s, [118]))
+    if len(categories) == 0:
+        # add genre and genreId like GP does when there're no categories available
+        categories.append({
+          'name': nested_lookup(s, [79, 0, 0, 0]),
+          'id': nested_lookup(s, [79, 0, 0, 2]),
+        })
+
+    return categories
 
 class ElementSpecs:
 
@@ -91,6 +113,9 @@ class ElementSpecs:
         # "developerInternalID": ElementSpec(5, [0, 12, 5, 0, 0]),
         "genre": ElementSpec(5, [1, 2, 79, 0, 0, 0]),
         "genreId": ElementSpec(5, [1, 2, 79, 0, 0, 2]),
+        "categories": ElementSpec(
+            5, [1, 2], get_categories, []
+        ),
         "icon": ElementSpec(5, [1, 2, 95, 0, 3, 2]),
         "headerImage": ElementSpec(5, [1, 2, 96, 0, 3, 2]),
         "screenshots": ElementSpec(

--- a/tests/e2e_tests/test_app.py
+++ b/tests/e2e_tests/test_app.py
@@ -57,6 +57,10 @@ class TestApp(TestCase):
         # self.assertEqual("8524055825995721370", result["developerInternalID"])
         self.assertEqual("Simulation", result["genre"])
         self.assertEqual("GAME_SIMULATION", result["genreId"])
+        self.assertTrue(result["categories"])
+        self.assertGreaterEqual(len(result["categories"]), 1)
+        self.assertEqual("Action", result["categories"][0]["name"])
+        self.assertEqual("GAME_ACTION", result["categories"][0]["id"])
         self.assertEqual(
             "https://play-lh.googleusercontent.com/5nPD6fyJaa-EDLHdlBd9UsaAV8KkfrYvLB956eQsvIGNBWUrPeouYw8aa7kbCbY--6E",
             result["icon"],


### PR DESCRIPTION
A copy of my [#622](https://github.com/facundoolano/google-play-scraper/pull/622) PR to Facundo's repo. 

Adds a list of `categories` to the app detail's result.

The code is placed straight into the `element.py` file because I don't understand where it should be in the structure. Also I don't really do python, so it's just an attempt to be helpful and give the idea on how to get the categories list GP shows them.

Solves #158 