### PR TITLE
Update extract_categories signature to init with a null list

### DIFF
--- a/google_play_scraper/constants/element.py
+++ b/google_play_scraper/constants/element.py
@@ -39,7 +39,10 @@ class ElementSpec:
         return result
 
 
-def extract_categories(s, categories=[]):
+def extract_categories(s, categories=None):
+    # Init an empty list if first iteration
+    if categories == None:
+        categories = []
     if s == None or len(s) == 0:
         return categories
 


### PR DESCRIPTION
Fix duplicate categories when iterating over several bundles
#193 