### PR TITLE
Add device filtering for reviews

### DIFF
--- a/google_play_scraper/__init__.py
+++ b/google_play_scraper/__init__.py
@@ -1,4 +1,4 @@
-from .constants.google_play import Sort  # noqa: F401
+from .constants.google_play import Sort, Device  # noqa: F401
 from .features.app import app  # noqa: F401
 from .features.permissions import permissions  # noqa: F401
 from .features.reviews import reviews, reviews_all  # noqa: F401

--- a/google_play_scraper/constants/google_play.py
+++ b/google_play_scraper/constants/google_play.py
@@ -4,3 +4,10 @@ from enum import Enum
 class Sort(int, Enum):
     NEWEST = 2
     MOST_RELEVANT = 1
+
+
+class Device(int, Enum):
+    MOBILE = 2
+    TABLET = 3
+    CHROMEBOOK = 5
+    TV = 6

--- a/google_play_scraper/constants/request.py
+++ b/google_play_scraper/constants/request.py
@@ -43,8 +43,8 @@ class Formats:
         def build(self, lang: str, country: str) -> str:
             return self.URL_FORMAT.format(lang=lang, country=country)
 
-        PAYLOAD_FORMAT_FOR_FIRST_PAGE = "f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C{sort}%2C%5B{count}%2Cnull%2Cnull%5D%2Cnull%2C%5Bnull%2C{score}%5D%5D%2C%5B%5C%22{app_id}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D"
-        PAYLOAD_FORMAT_FOR_PAGINATED_PAGE = "f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C{sort}%2C%5B{count}%2Cnull%2C%5C%22{pagination_token}%5C%22%5D%2Cnull%2C%5Bnull%2C{score}%5D%5D%2C%5B%5C%22{app_id}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D"
+        PAYLOAD_FORMAT_FOR_FIRST_PAGE = "f.req=%5B%5B%5B%22oCPfdb%22%2C%22%5Bnull%2C%5B2%2C{sort}%2C%5B{count}%5D%2Cnull%2C%5Bnull%2C{score}%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C{device_id}%5D%5D%2C%5B%5C%22{app_id}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D%0A"
+        PAYLOAD_FORMAT_FOR_PAGINATED_PAGE = "f.req=%5B%5B%5B%22oCPfdb%22%2C%22%5Bnull%2C%5B2%2C{sort}%2C%5B{count}%2Cnull%2C%5C%22{pagination_token}%5C%22%5D%2Cnull%2C%5Bnull%2C{score}%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C{device_id}%5D%5D%2C%5B%5C%22{app_id}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D%0A"
 
         def build_body(
             self,
@@ -52,6 +52,7 @@ class Formats:
             sort: int,
             count: int,
             filter_score_with: int,
+            filter_device_with: int,
             pagination_token: str,
         ) -> bytes:
             if pagination_token is not None:
@@ -60,13 +61,13 @@ class Formats:
                     sort=sort,
                     count=count,
                     score=filter_score_with,
+                    device_id=filter_device_with,
                     pagination_token=pagination_token,
                 )
             else:
                 result = self.PAYLOAD_FORMAT_FOR_FIRST_PAGE.format(
-                    app_id=app_id, sort=sort, score=filter_score_with, count=count
+                    app_id=app_id, sort=sort, count=count, score=filter_score_with, device_id=filter_device_with
                 )
-
             return result.encode()
 
     class _Permissions(Format):


### PR DESCRIPTION
Add device filtering for reviews:
- Add Device Enum in `google_play.py`
- Added device_id parameter in `request.py` and `reviews.py`
- Changed request type from `"UsvDTd"` to `"oCPfdb"` (which allows device filtering)

Decoded formats:
- Without pagination token: `[[["oCPfdb","[null,[2,{sort},[{count}],null,[null,{score},null,null,null,null,null,null,{device}]],[\"com.fantome.penguinisle\",7]]",null,"generic"]]]`
- With pagination token: `[[["oCPfdb","[null,[2,{sort},[{count},null,\"{pagination_token}\"],null,[null,{score},null,null,null,null,null,null,{device}]],[\"com.fantome.penguinisle\",7]]",null,"generic"]]]`