### PR TITLE
European countries not working for Google Play Search - fixed for latest Google Playstore Web UI 2025

### DIFF
--- a/google_play_scraper/features/search.py
+++ b/google_play_scraper/features/search.py
@@ -41,7 +41,7 @@ def search(
         top_result = dataset["ds:4"][0][1][0][23][16]
     except:
         try:
-            top_result = dataset["ds:3"][0][1][0][23][16]
+            top_result = dataset["ds:4"][0][1][1][23][16]
         except (IndexError, KeyError, TypeError):
             top_result = None
 
@@ -69,7 +69,7 @@ def search(
         else []
     )
 
-    for app_idx in range(n_apps - len(search_results)):
+    for app_idx in range(n_apps):
         app = {}
         for k, spec in ElementSpecs.SearchResult.items():
             content = spec.extract_content(dataset[app_idx])

--- a/google_play_scraper/features/search.py
+++ b/google_play_scraper/features/search.py
@@ -39,8 +39,11 @@ def search(
 
     try:
         top_result = dataset["ds:4"][0][1][0][23][16]
-    except IndexError:
-        top_result = None
+    except:
+        try:
+            top_result = dataset["ds:3"][0][1][0][23][16]
+        except (IndexError, KeyError, TypeError):
+            top_result = None
 
     success = False
     # different idx for different countries and languages


### PR DESCRIPTION
Previously, for European countries, the Google Play Scraper was crashing into errors because of some changes in the Google Play playstore ui, so I had rectified and fixed the issue and resolved the bug so that it will not crash and give the scraped data for European countries also.